### PR TITLE
Update .editorconfig to enforce indent size 2 in markdown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,3 +23,8 @@ indent_size = 2
 [*.go]
 # `gofmt` uses tabs for indentation
 indent_style = tab
+
+# For Go code snippets inserted to markdown
+[*.md]
+indent_style = tab
+indent_size = 2


### PR DESCRIPTION
resolves https://github.com/MiryangJung/learn-go-with-tests-ko/issues/48

참고로 원문에 삽입된 Go 코드의 탭 사이즈는 8입니다. (e.g. https://github.com/MiryangJung/learn-go-with-tests-ko/blob/master/context.md)